### PR TITLE
Add plugin config function

### DIFF
--- a/Common/Gfx/Util/D2DBitmapLoader.cpp
+++ b/Common/Gfx/Util/D2DBitmapLoader.cpp
@@ -75,7 +75,7 @@ HRESULT D2DBitmapLoader::LoadBitmapFromFile(const Canvas& canvas, D2DBitmap* bit
 }
 
 HRESULT D2DBitmapLoader::LoadBitmapFromMemory(const Canvas& canvas, D2DBitmap* bitmap,
-	UINT8* imagePixels, INT32 imageWidth, INT32 imageHeight, INT64 imageTimestamp)
+	UINT32* imagePixels, INT32 imageWidth, INT32 imageHeight)
 {
 	if (!bitmap) return E_FAIL;
 

--- a/Common/Gfx/Util/D2DBitmapLoader.cpp
+++ b/Common/Gfx/Util/D2DBitmapLoader.cpp
@@ -86,7 +86,7 @@ HRESULT D2DBitmapLoader::LoadBitmapFromMemory(const Canvas& canvas, D2DBitmap* b
 
 	HRESULT hr = Gfx::Canvas::c_WICFactory->CreateBitmapFromMemory(
 		(UINT)imageWidth, (UINT)imageHeight,
-		GUID_WICPixelFormat32bppBGRA, (UINT)imageWidth * 4 ,
+		GUID_WICPixelFormat32bppRGBA, (UINT)imageWidth * 4 ,
 		((UINT)imageWidth * (UINT)imageHeight * 4) * sizeof(unsigned char),
 		reinterpret_cast<BYTE*>(imagePixels), &iwicBitmap);
 

--- a/Common/Gfx/Util/D2DBitmapLoader.h
+++ b/Common/Gfx/Util/D2DBitmapLoader.h
@@ -18,7 +18,7 @@ class D2DBitmapLoader
 public:
 	static HRESULT LoadBitmapFromFile(const Canvas& canvas, D2DBitmap* bitmap);
 	static HRESULT LoadBitmapFromMemory(const Canvas& canvas, D2DBitmap* bitmap,
-		UINT8* imagePixels, INT32 imageWidth, INT32 imageHeight, INT64 imageTimestamp);
+		UINT32* imagePixels, INT32 imageWidth, INT32 imageHeight);
 
 	static bool HasFileChanged(D2DBitmap* bitmap, const std::wstring& file);
 	static HRESULT GetFileInfo(const std::wstring& path, FileInfo* fileInfo);
@@ -29,7 +29,7 @@ private:
 	D2DBitmapLoader() = delete;
 	~D2DBitmapLoader() = delete;
 	D2DBitmapLoader(const D2DBitmapLoader& other) = delete;
-	D2DBitmapLoader& operator=(D2DBitmapLoader other) = delete;
+	D2DBitmapLoader& operator=(D2DBitmapLoader& other) = delete;
 
 	static HRESULT CreateBitmap(const Canvas& canvas, D2DBitmap* bitmap, HRESULT& hr,
 	Microsoft::WRL::ComPtr<IWICBitmapSource> source, HANDLE fileHandle = nullptr);

--- a/Library/Export.cpp
+++ b/Library/Export.cpp
@@ -57,6 +57,27 @@ LPCWSTR __stdcall RmPathToAbsolute(void* rm, LPCWSTR relativePath)
 	return g_Buffer.c_str();
 }
 
+extern "C" {
+	static LPCWSTR __stdcall RmGet_GetPluginConfig(void* rm, LPCWSTR name)
+	{
+		if (rm == nullptr)
+		{
+			return nullptr;
+		}
+		MeasurePlugin* measure = (MeasurePlugin*)rm;
+		return measure->getConfig(name);
+	}
+	static LPCWSTR __stdcall RmGet_SetPluginConfig(void* rm, LPCWSTR name, LPCWSTR value)
+	{
+		if (rm == nullptr)
+		{
+			return nullptr;
+		}
+		MeasurePlugin* measure = (MeasurePlugin*)rm;
+		return measure->setConfig(name, value);
+	}
+}
+
 void* __stdcall RmGet(void* rm, int type)
 {
 	MeasurePlugin* measure = (MeasurePlugin*)rm;
@@ -90,6 +111,16 @@ void* __stdcall RmGet(void* rm, int type)
 			Skin* window = measure->GetSkin();
 			if (!window) break;
 			return (void*)window->GetWindow();
+		}
+
+	case RMG_MEASURECONFIGSET:
+		{
+			return (void*)RmGet_SetPluginConfig;
+		}
+
+	case RMG_MEASURECONFIGGET:
+		{
+			return (void*)RmGet_GetPluginConfig;
 		}
 	}
 

--- a/Library/GeneralImage.cpp
+++ b/Library/GeneralImage.cpp
@@ -312,9 +312,9 @@ bool GeneralImage::LoadImageFromPluginMeasure(MeasurePlugin* mPlugin)
 	INT32 imageWidth = 0;
 	INT32 imageHeight = 0;
 	INT64 imageTimestamp = 0;
-	UINT8* imagePixels = nullptr;
+	UINT32* imagePixels = nullptr;
 
-	auto success = mPlugin->GetImageData(&imagePixels, imageWidth, imageHeight, imageTimestamp, nullptr);
+	auto success = mPlugin->GetImageData(imagePixels, imageWidth, imageHeight, imageTimestamp);
 	if (!success)
 	{
 		DisposeImage();
@@ -328,7 +328,7 @@ bool GeneralImage::LoadImageFromPluginMeasure(MeasurePlugin* mPlugin)
 	{
 		auto bitmap = new Gfx::D2DBitmap();
 		HRESULT hr = Gfx::Util::D2DBitmapLoader::LoadBitmapFromMemory(m_Skin->GetCanvas(), bitmap,
-			imagePixels, imageWidth, imageHeight, imageTimestamp);
+			imagePixels, imageWidth, imageHeight);
 
 		if (SUCCEEDED(hr))
 		{

--- a/Library/MeasurePlugin.cpp
+++ b/Library/MeasurePlugin.cpp
@@ -221,16 +221,16 @@ const WCHAR* MeasurePlugin::GetStringValue()
 
 /*
 ** Gets the image data from plugin (if available).
-**
+** Returns true if plugin provided the image, false otherwise.
 */
-const WCHAR* MeasurePlugin::GetImageData(UINT8** imagePixels, INT32& imageWidth, INT32& imageHeight, INT64& imageTimestamp, void* reserved)
+bool MeasurePlugin::GetImageData(UINT32*& imagePixels, INT32& imageWidth, INT32& imageHeight, INT64& imageTimestamp)
 {
 	if (m_GetImageFunc)
 	{
-		bool ret = ((GETIMAGE)m_GetImageFunc)(m_PluginData, imagePixels, imageWidth, imageHeight, imageTimestamp, reserved);
-		if (ret) return L"";
+		const auto res = ((GETIMAGE)m_GetImageFunc)(m_PluginData, &imagePixels, &imageWidth, &imageHeight, &imageTimestamp);
+		return res != 0;
 	}
-	return nullptr;
+	return false;
 }
 
 /*

--- a/Library/MeasurePlugin.cpp
+++ b/Library/MeasurePlugin.cpp
@@ -225,7 +225,7 @@ const WCHAR* MeasurePlugin::GetStringValue()
 */
 bool MeasurePlugin::GetImageData(UINT32*& imagePixels, INT32& imageWidth, INT32& imageHeight, INT64& imageTimestamp)
 {
-	if (m_GetImageFunc)
+	if (m_AllowImageTransfer && m_GetImageFunc)
 	{
 		const auto res = ((GETIMAGE)m_GetImageFunc)(m_PluginData, &imagePixels, &imageWidth, &imageHeight, &imageTimestamp);
 		return res != 0;
@@ -290,6 +290,10 @@ bool MeasurePlugin::CommandWithReturn(const std::wstring& command, std::wstring&
 			function == "GetPluginAuthor" ||		// Old API
 			function == "GetPluginVersion")			// Old API
 			return false;
+		if (m_AllowImageTransfer && function == "GetImage")
+		{
+			return false;
+		}
 
 		// Parse arguments
 		auto _args = ConfigParser::Tokenize2(
@@ -325,4 +329,32 @@ bool MeasurePlugin::CommandWithReturn(const std::wstring& command, std::wstring&
 	}
 
 	return false;
+}
+
+const WCHAR* MeasurePlugin::setConfig(const WCHAR* name, const WCHAR* value)
+{
+	if (_wcsicmp(name, L"image-transfer") == 0)
+	{
+		if (_wcsicmp(value, L"true") == 0)
+		{
+			m_AllowImageTransfer = true;
+			return L"ok";
+		}
+		if (_wcsicmp(value, L"false") == 0)
+		{
+			m_AllowImageTransfer = false;
+			return L"ok";
+		}
+		return L"invalid value";
+	}
+	return L"unknown name";
+}
+
+const WCHAR* MeasurePlugin::getConfig(const WCHAR* name) const
+{
+	if (_wcsicmp(name, L"image-transfer") == 0)
+	{
+		return m_AllowImageTransfer ? L"true" : L"false";
+	}
+	return nullptr;
 }

--- a/Library/MeasurePlugin.cpp
+++ b/Library/MeasurePlugin.cpp
@@ -228,7 +228,7 @@ bool MeasurePlugin::GetImageData(UINT32*& imagePixels, INT32& imageWidth, INT32&
 	if (m_AllowImageTransfer && m_GetImageFunc)
 	{
 		const auto res = ((GETIMAGE)m_GetImageFunc)(m_PluginData, &imagePixels, &imageWidth, &imageHeight, &imageTimestamp);
-		return res != 0;
+		return res != nullptr;
 	}
 	return false;
 }

--- a/Library/MeasurePlugin.h
+++ b/Library/MeasurePlugin.h
@@ -23,7 +23,7 @@ typedef void (*NEWRELOAD)(void*, void*, double*);
 typedef void (*NEWFINALIZE)(void*);
 typedef double (*NEWUPDATE)(void*);
 typedef LPCWSTR (*NEWGETSTRING)(void*);
-typedef bool (*GETIMAGE)(void*, UINT8**, INT32&, INT32&, INT64&, void*);
+typedef INT32 (*GETIMAGE)(void*, UINT32**, INT32*, INT32*, INT64*);
 typedef void (*NEWEXECUTEBANG)(void*, LPCWSTR);
 
 typedef LPCWSTR(*CUSTOMFUNCTION)(void*, const int, const WCHAR* argv[]);
@@ -40,7 +40,7 @@ public:
 	virtual UINT GetTypeID() { return TypeID<MeasurePlugin>(); }
 
 	virtual const WCHAR* GetStringValue();
-	const WCHAR* GetImageData(UINT8** imagePixels, INT32& imageWidth, INT32& imageHeight, INT64& imageTimestamp, void* reserved);
+	bool GetImageData(UINT32*& imagePixels, INT32& imageWidth, INT32& imageHeight, INT64& imageTimestamp);
 	virtual void Command(const std::wstring& command);
 
 	bool CommandWithReturn(const std::wstring& command, std::wstring& strValue);

--- a/Library/MeasurePlugin.h
+++ b/Library/MeasurePlugin.h
@@ -45,6 +45,9 @@ public:
 
 	bool CommandWithReturn(const std::wstring& command, std::wstring& strValue);
 
+	const WCHAR* setConfig(const WCHAR* name, const WCHAR* value);
+	const WCHAR* getConfig(const WCHAR* name) const;
+
 protected:
 	virtual void ReadOptions(ConfigParser& parser, const WCHAR* section);
 	virtual void UpdateValue();
@@ -74,6 +77,8 @@ private:
 	void* m_GetStringFunc;
 	void* m_GetImageFunc;
 	void* m_ExecuteBangFunc;
+
+	bool m_AllowImageTransfer;
 };
 
 #endif

--- a/Library/MeasurePlugin.h
+++ b/Library/MeasurePlugin.h
@@ -23,7 +23,7 @@ typedef void (*NEWRELOAD)(void*, void*, double*);
 typedef void (*NEWFINALIZE)(void*);
 typedef double (*NEWUPDATE)(void*);
 typedef LPCWSTR (*NEWGETSTRING)(void*);
-typedef INT32 (*GETIMAGE)(void*, UINT32**, INT32*, INT32*, INT64*);
+typedef LPCWSTR (*GETIMAGE)(void*, UINT32**, INT32*, INT32*, INT64*);
 typedef void (*NEWEXECUTEBANG)(void*, LPCWSTR);
 
 typedef LPCWSTR(*CUSTOMFUNCTION)(void*, const int, const WCHAR* argv[]);

--- a/Library/MeterImage.cpp
+++ b/Library/MeterImage.cpp
@@ -62,7 +62,12 @@ void MeterImage::LoadImageFromFile(const std::wstring& imageName, bool bLoadAlwa
 
 bool MeterImage::LoadImageFromPluginMeasure(MeasurePlugin *mPlugin)
 {
-	return m_Image.LoadImageFromPluginMeasure(mPlugin);
+	auto loaded = m_Image.LoadImageFromPluginMeasure(mPlugin);
+	if (loaded)
+	{
+		CalcImageDimensions();
+	}
+	return loaded;
 }
 
 /*
@@ -187,7 +192,6 @@ bool MeterImage::Update()
 					{
 						if (LoadImageFromPluginMeasure(plugin_measure))
 						{
-							CalcImageDimensions();
 							return true;
 						}
 					}

--- a/Plugins/API/RainmeterAPI.h
+++ b/Plugins/API/RainmeterAPI.h
@@ -139,7 +139,9 @@ enum RmGetType
 	RMG_SKIN             = 1,
 	RMG_SETTINGSFILE     = 2,
 	RMG_SKINNAME         = 3,
-	RMG_SKINWINDOWHANDLE = 4
+	RMG_SKINWINDOWHANDLE = 4,
+	RMG_MEASURECONFIGSET = 5,
+	RMG_MEASURECONFIGGET = 6,
 };
 
 /// <summary>
@@ -349,6 +351,86 @@ __inline LPCWSTR RmGetSkinName(void* rm)
 __inline HWND RmGetSkinWindow(void* rm)
 {
 	return (HWND)RmGet(rm, RMG_SKINWINDOWHANDLE);
+}
+
+/// <summary>
+/// Changes how the measure behaves. See the documentation to learn about allowed values.
+/// </summary>
+/// <remarks>Obtain using RmGetPluginConfigSet() in the Initialize function and set all values that you need</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
+/// <returns>Returns a pointer to the function</returns>
+/// <example>
+/// <code>
+/// PLUGIN_EXPORT void Initialize(void** data, void* rm)
+/// {
+/// 	Measure* measure = new Measure;
+/// 	*data = measure;
+/// 	auto RmPluginConfigSet = RmGetPluginConfigSet(rm);
+/// 	RmPluginConfigSet(L"image-transfer", L"true");
+/// }
+/// </code>
+/// </example>
+typedef const WCHAR* (*t_RmPluginConfigSet)(void* rm, LPCWSTR name, LPCWSTR value);
+
+/// <summary>
+/// Returns a pointer to the function RmPluginConfigSet.
+/// </summary>
+/// <remarks>Call RmGetPluginConfigSet() in the Initialize function and set all values that you need</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
+/// <returns>Returns a pointer to the function</returns>
+/// <example>
+/// <code>
+/// PLUGIN_EXPORT void Initialize(void** data, void* rm)
+/// {
+/// 	Measure* measure = new Measure;
+/// 	*data = measure;
+/// 	auto RmPluginConfigSet = RmGetPluginConfigSet(rm);
+/// }
+/// </code>
+/// </example>
+__inline t_RmPluginConfigSet RmGetPluginConfigSet(void* rm)
+{
+	return (t_RmPluginConfigSet)RmGet(rm, RMG_MEASURECONFIGSET);
+}
+
+/// <summary>
+/// Returns current value of the configuration. See the documentation to learn about allowed values.
+/// </summary>
+/// <remarks>Obtain using RmGetPluginConfigGet() in the Initialize function and check the values</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
+/// <returns>Returns a pointer to the function</returns>
+/// <example>
+/// <code>
+/// PLUGIN_EXPORT void Initialize(void** data, void* rm)
+/// {
+/// 	Measure* measure = new Measure;
+/// 	*data = measure;
+/// 	auto RmPluginConfigGet = RmGetPluginConfigGet(rm);
+/// 	auto value = RmPluginConfigGet(L"image-transfer");
+/// }
+/// </code>
+/// </example>
+typedef const WCHAR* (*t_RmPluginConfigGet)(void* rm, LPCWSTR name);
+
+/// <summary>
+/// Returns a pointer to the function RmPluginConfigGet.
+/// </summary>
+/// <remarks>Call RmGetPluginConfigGet() in the Initialize function and check the values</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
+/// <returns>Returns a pointer to the function</returns>
+/// <example>
+/// <code>
+/// PLUGIN_EXPORT void Initialize(void** data, void* rm)
+/// {
+/// 	Measure* measure = new Measure;
+/// 	*data = measure;
+/// 	auto RmPluginConfigGet = RmGetPluginConfigGet(rm);
+/// }
+/// </code>
+/// </example>
+__inline t_RmPluginConfigGet RmGetPluginConfigGet(void* rm)
+{
+	return (t_RmPluginConfigGet)RmGet(rm, RMG_MEASURECONFIGGET);
 }
 
 /// <summary>


### PR DESCRIPTION
I changed few things.

Obviously, I added the config function.

After some thoughts I decided that any `reserved` parameter is kinds useless, because if we really wanted to introduce something new we could extend the config function to accept new values.

`GetImage` has `const wchar_t*` return type for compatibility.

I changed pixel layout because BGRA seems to be extremely slow here.

## Reference plugin
<details>

```cpp
#include <cstdint>
#include <ctime>
#include <string>
#include <vector>

#include "RainmeterAPI.h"

#pragma comment(lib, "Rainmeter.lib")

struct Pixel {
	uint8_t red;
	uint8_t green;
	uint8_t blue;
	uint8_t alpha;
};

struct MeasureData {
	bool imagesAllowed = false;
	int32_t width = 0;
	int32_t height = 0;
	int64_t timestamp = 0;
	std::vector<Pixel> pixels{};
	uint32_t seed = 0;

	uint8_t nextRand() {
		seed = (214013u * seed + 2531011u);
		return uint8_t((seed >> 16) & 0x7FFFu);
	}
};

PLUGIN_EXPORT void Initialize(void** data, void* rm) {
	auto md = new MeasureData();
	*data = md;

	auto configSet = RmGetPluginConfigSet(rm);
	if (configSet == nullptr) {
		RmLog(rm, LOG_ERROR, L"this plugin requires rainmeter in-memory transfer support");
		return;
	}
	std::wstring setResult = configSet(rm, L"image-transfer", L"true");
	if (setResult != L"ok") {
		RmLog(rm, LOG_ERROR, L"this plugin requires rainmeter in-memory transfer support");
		return;
	}
	
	md->width = 1000;
	md->height = 500;
	md->pixels.resize(md->width * md->height);
	md->imagesAllowed = true;
}

PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue) {}

PLUGIN_EXPORT double Update(void* data) {
	const auto md = static_cast<MeasureData*>(data);
	if (!md->imagesAllowed) return 0.0;
	
	for (int i = 0; i < md->width * md->height; ++i) {
		md->pixels[i].alpha = 255;
		md->pixels[i].red = md->nextRand();
		md->pixels[i].green = md->nextRand();
		md->pixels[i].blue = md->nextRand();
	}
	md->timestamp++;

	return 1.0;
}

PLUGIN_EXPORT LPCWSTR GetString(void* data) {
	return L"use images, not paths";
}

PLUGIN_EXPORT void Finalize(void* data) {
	delete static_cast<MeasureData*>(data);
}

PLUGIN_EXPORT const wchar_t* GetImage(void* data, uint32_t** pixels, int32_t* width, int32_t* height, int64_t* timestamp) {
	const auto md = static_cast<MeasureData*>(data);
	if (!md->imagesAllowed) return nullptr;
	
	*pixels = reinterpret_cast<uint32_t*>(md->pixels.data());
	*width = md->width;
	*height = md->height;
	*timestamp = md->timestamp;
	return L"";
}
```
</details>

We [hopefully] have full compatibility between and and new plugins and rainmeter.
In old rainmeter version `GetImage` could get called with signature `const wchar_t*(void* data, const int argc, const wchar_t* argv[])`, so we must be careful not to touch the arguments until we are sure that in-memory image transfer is enabled.